### PR TITLE
rqscheduler can constantly attempt to register itself.

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -28,10 +28,16 @@ class Scheduler(object):
         self._interval = interval
         self.log = logger
 
-    def register_birth(self):
-        if self.connection.exists(self.scheduler_key) and \
-                not self.connection.hexists(self.scheduler_key, 'death'):
-            raise ValueError("There's already an active RQ scheduler")
+    def register_birth(self, retry=False):
+        while True:
+            if self.connection.exists(self.scheduler_key) and \
+                    not self.connection.hexists(self.scheduler_key, 'death'):
+                if not retry:
+                    raise ValueError("There's already an active RQ scheduler")
+                self.log.info('RQ scheduler already active...')
+                time.sleep(self._interval)
+            else:
+                break
         key = self.scheduler_key
         now = time.time()
         with self.connection._pipeline() as p:
@@ -302,13 +308,13 @@ class Scheduler(object):
         self.connection.expire(self.scheduler_key, self._interval + 10)
         return jobs
 
-    def run(self):
+    def run(self, retry=False):
         """
         Periodically check whether there's any job that should be put in the queue (score
         lower than current time).
         """
         self.log.info('Running RQ scheduler...')
-        self.register_birth()
+        self.register_birth(retry=retry)
         self._install_signal_handlers()
         try:
             while True:

--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -25,6 +25,8 @@ def main():
             queue (in seconds).")
     parser.add_argument('--path', default='.', help='Specify the import path.')
     parser.add_argument('--pid', help='A filename to use for the PID file.', metavar='FILE')
+    help = 'Keep retrying to register scheduler if one already exists.'
+    parser.add_argument('--retry', action='store_true', help=help)
     
     args = parser.parse_args()
     
@@ -49,7 +51,7 @@ def main():
     setup_loghandlers(level)
 
     scheduler = Scheduler(connection=connection, interval=args.interval)
-    scheduler.run()
+    scheduler.run(retry=args.retry)
 
 if __name__ == '__main__':
     main()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -52,6 +52,20 @@ class TestScheduler(RQTestCase):
         scheduler.register_death()
         self.assertTrue(self.testconn.hexists(key, 'death'))
 
+    def test_birth_scheduler_already_active(self):
+        """
+        Verifies that multiple schedulers can be started and they can wait for
+        another to die before registering itself.
+        """
+        key = Scheduler.scheduler_key
+        self.assertNotIn(key, tl(self.testconn.keys('*')))
+        scheduler = Scheduler(connection=self.testconn, interval=20)
+        scheduler.register_birth()
+        scheduler.register_death()
+        retrying_scheduler = Scheduler(connection=self.testconn, interval=20)
+        retrying_scheduler.register_birth(retry=True)
+        retrying_scheduler.register_death()
+
     def test_create_job(self):
         """
         Ensure that jobs are created properly.


### PR DESCRIPTION
Allow rqscheduler to keep attempting to register itself periodically.

My use case is that I have N identical hosts all running rqworker and rqscheduler processes under the watchful eye of supervisor.  As supevisord doesn't support an 'unlimited' value for the 'startretries' program configuration option, eventually the rqscheduler process will be moved into supervisor's failed state.  Thus, if the host that was successfully running rqscheduler goes down, none of the other existing hosts can automatically take its place.

Similarly, when performing rolling updates, the new hosts come online and try to launch rqscheduler.  This fails because an old host is already executing it.  If the rollout is slow, it's possible that the new hosts will again have put rqscheduler into a failed state before the old host is rolled out.  This will result in a new deployment where rqscheduler is not running.

This patch will allow rqscheduler itself to keep retrying its registration process.  Backwards compatability is preserved by aborting by default.