### PR TITLE
adds support for rqworker settings files

### DIFF
--- a/rq_scheduler/__init__.py
+++ b/rq_scheduler/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 5, 1)
+VERSION = (0, 5, 2)
 
 from .scheduler import Scheduler

--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -8,16 +8,49 @@ from redis import Redis
 from rq_scheduler.scheduler import Scheduler
 
 from rq.logutils import setup_loghandlers
+from rq.cli import helpers
 
+
+KEY_HOST = "host"
+KEY_PORT = "port"
+KEY_DB = "db"
+KEY_PASSWORD = "password"
+KEY_URL = "url"
 
 def main():
-    parser = argparse.ArgumentParser(description='Runs RQ scheduler')
-    parser.add_argument('-H', '--host', default=os.environ.get('RQ_REDIS_HOST', 'localhost'), help="Redis host")
-    parser.add_argument('-p', '--port', default=int(os.environ.get('RQ_REDIS_PORT', 6379)), type=int, help="Redis port number")
-    parser.add_argument('-d', '--db', default=int(os.environ.get('RQ_REDIS_DB', 0)), type=int, help="Redis database")
-    parser.add_argument('-P', '--password', default=os.environ.get('RQ_REDIS_PASSWORD'), help="Redis password")
+
+    # set up minimal argparser to get -c option
+    parser = argparse.ArgumentParser(
+        add_help=False  # help will be picked up later when we redfine parser
+    )
+    parser.add_argument('-c', "--config", help='Use an rq config file')
+    args, remaining_argv = parser.parse_known_args()
+
+    # config, pass 1: read environment vars
+    config = {
+        KEY_HOST : os.environ.get('RQ_REDIS_HOST', 'localhost'),
+        KEY_PORT : int(os.environ.get('RQ_REDIS_PORT', 6379)),
+        KEY_DB : int(os.environ.get('RQ_REDIS_DB', 0)),
+        KEY_PASSWORD : os.environ.get('RQ_REDIS_PASSWORD'),
+        KEY_URL : os.environ.get('RQ_REDIS_URL')
+    }
+
+    # config, pass 2: read config file
+    if args.config:
+        rq_config = helpers.read_config_file( args.config )
+        # map rq settings to our own config dict
+        config[KEY_URL] = rq_config["REDIS_URL"] or config[KEY_URL]
+
+    # config, pass 3: read commandline args. overwrites any other config.
+    parser = argparse.ArgumentParser(
+        parents=[parser]  # inherit from existing parser
+    )
+    parser.add_argument('-H', '--host', default=config[KEY_HOST], help="Redis host")
+    parser.add_argument('-p', '--port', default=config[KEY_PORT], type=int, help="Redis port number")
+    parser.add_argument('-d', '--db', default=config[KEY_DB], type=int, help="Redis database")
+    parser.add_argument('-P', '--password', default=config[KEY_PASSWORD], help="Redis password")
     parser.add_argument('--verbose', '-v', action='store_true', default=False, help='Show more output')
-    parser.add_argument('--url', '-u', default=os.environ.get('RQ_REDIS_URL')
+    parser.add_argument('--url', '-u', default=config[KEY_URL]
         , help='URL describing Redis connection details. \
             Overrides other connection arguments if supplied.')
     parser.add_argument('-i', '--interval', default=60.0, type=float
@@ -26,7 +59,7 @@ def main():
     parser.add_argument('--path', default='.', help='Specify the import path.')
     parser.add_argument('--pid', help='A filename to use for the PID file.', metavar='FILE')
     
-    args = parser.parse_args()
+    args = parser.parse_args( remaining_argv )
     
     if args.path:
         sys.path = args.path.split(':') + sys.path

--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -37,6 +37,7 @@ def main():
 
     # config, pass 2: read config file
     if args.config:
+        sys.path.append( os.path.dirname(os.path.realpath(args.config)) )
         rq_config = helpers.read_config_file( args.config )
         # map rq settings to our own config dict
         config[KEY_URL] = rq_config["REDIS_URL"] or config[KEY_URL]

--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -37,14 +37,15 @@ def main():
 
     # config, pass 2: read config file
     if args.config:
+        # bit of a hack, this, but does allow helpers.read_config_file to work...
         sys.path.append( os.path.dirname(os.path.realpath(args.config)) )
         rq_config = helpers.read_config_file( args.config )
         # map rq settings to our own config dict
-        config[KEY_URL] = rq_config["REDIS_URL"] or config[KEY_URL]
-        config[KEY_HOST] = rq_config["REDIS_HOST"] or config[KEY_HOST]
-        config[KEY_PORT] = rq_config["REDIS_PORT"] or config[KEY_PORT]
-        config[KEY_DB] = rq_config["REDIS_DB"] or config[KEY_DB]
-        config[KEY_PASSWORD] = rq_config["REDIS_PASSWORD"] or config[KEY_PASSWORD]
+        config[KEY_URL] = rq_config.get("REDIS_URL", config[KEY_URL])
+        config[KEY_HOST] = rq_config.get("REDIS_HOST", config[KEY_HOST])
+        config[KEY_PORT] = rq_config.get("REDIS_PORT", config[KEY_PORT])
+        config[KEY_DB] = rq_config.get("REDIS_DB", config[KEY_DB])
+        config[KEY_PASSWORD] = rq_config.get("REDIS_PASSWORD",config[KEY_PASSWORD])
 
     # config, pass 3: read commandline args. overwrites any other config.
     parser = argparse.ArgumentParser(

--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -40,6 +40,10 @@ def main():
         rq_config = helpers.read_config_file( args.config )
         # map rq settings to our own config dict
         config[KEY_URL] = rq_config["REDIS_URL"] or config[KEY_URL]
+        config[KEY_HOST] = rq_config["REDIS_HOST"] or config[KEY_HOST]
+        config[KEY_PORT] = rq_config["REDIS_PORT"] or config[KEY_PORT]
+        config[KEY_DB] = rq_config["REDIS_DB"] or config[KEY_DB]
+        config[KEY_PASSWORD] = rq_config["REDIS_PASSWORD"] or config[KEY_PASSWORD]
 
     # config, pass 3: read commandline args. overwrites any other config.
     parser = argparse.ArgumentParser(

--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -38,7 +38,7 @@ def main():
     # config, pass 2: read config file
     if args.config:
         # bit of a hack, this, but does allow helpers.read_config_file to work...
-        sys.path.append( os.path.dirname(os.path.realpath(args.config)) )
+        sys.path.insert( 0, os.path.dirname(os.path.realpath(args.config)) )
         rq_config = helpers.read_config_file( args.config )
         # map rq settings to our own config dict
         config[KEY_URL] = rq_config.get("REDIS_URL", config[KEY_URL])

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if platform.python_version() < '2.7':
 
 setup(
     name='rq-scheduler',
-    version='0.5.1',
+    version='0.5.2',
     author='Selwin Ong',
     author_email='selwin.ong@gmail.com',
     packages=['rq_scheduler'],


### PR DESCRIPTION
as detailed at http://python-rq.org/docs/workers/

Allows rq-scheduler to read from these config files, thus enabling sharing of config with rqworker.