### PR TITLE
Configure logger (fix #69)

### DIFF
--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -7,7 +7,7 @@ import os
 from redis import Redis
 from rq_scheduler.scheduler import Scheduler
 
-from rq.logutils import setup_loghandlers
+from rq_scheduler.utils import setup_loghandlers
 
 
 def main():

--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -1,5 +1,9 @@
 import calendar
 from datetime import datetime
+import logging
+
+from rq.utils import ColorizingStreamHandler
+
 
 # from_unix from times.from_unix()
 def from_unix(string):
@@ -11,3 +15,15 @@ def from_unix(string):
 def to_unix(dt):
     """Converts a datetime object to unixtime"""
     return calendar.timegm(dt.utctimetuple())
+
+
+def setup_loghandlers(level='INFO'):
+    logger = logging.getLogger('rq_scheduler.scheduler')
+    if not logger.handlers:
+        logger.setLevel(level)
+        formatter = logging.Formatter(fmt='%(asctime)s %(message)s',
+                                      datefmt='%H:%M:%S')
+        handler = ColorizingStreamHandler()
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+


### PR DESCRIPTION
Same as `rq.logutils.setup_loghandlers()` but wirth the correct logger. I suppose the initial intention was to "do it how `rq` does", so it should be fine.