### PR TITLE
add options to handle stale jobs

### DIFF
--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -25,6 +25,12 @@ def main():
             queue (in seconds, can be floating-point for more precision).")
     parser.add_argument('--path', default='.', help='Specify the import path.')
     parser.add_argument('--pid', help='A filename to use for the PID file.', metavar='FILE')
+
+    # add options when rq_scheduler exited unexpectedly, and when it restarts again later, to check the stale jobs not
+    # to be executed automatically, and move them to stale queue
+    parser.add_argument('--max-stale-hours', default=None, type=float,
+                        help='A float, max stale hours that make recent past or future scheduled jobs marked as stale')
+    parser.add_argument('--stale-queue-name', default='stale', help='The queue name stored all the stale jobs')
     
     args = parser.parse_args()
     
@@ -48,7 +54,7 @@ def main():
         level = 'INFO'
     setup_loghandlers(level)
 
-    scheduler = Scheduler(connection=connection, interval=args.interval)
+    scheduler = Scheduler(connection=connection, interval=args.interval, max_stale_hours=args.max-stale-hours, stale_queue_name=args.stale-queue-name)
     scheduler.run()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Here is my situation, one day the scheduler process exited unexpectedly,  and after some days, when someone found this issue, and restarted it, the scheduler checked the now time, and enqueued all the stale jobs to the working queue and were executed. But the question is some stale jobs that I do not want to execute, or I just want to execute the recently stale jobs.

So I create this pull request to check the stale jobs once when the scheduler starts, and when we find stale jobs, move them to stale queue from scheduler, and check them later.