### PR TITLE
Add hostname to scheduler key

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -9,6 +9,7 @@ from itertools import repeat
 from rq.exceptions import NoSuchJobError
 from rq.job import Job
 from rq.queue import Queue
+from platform import node
 
 from redis import WatchError
 
@@ -37,6 +38,7 @@ class Scheduler(object):
         with self.connection._pipeline() as p:
             p.delete(key)
             p.hset(key, 'birth', now)
+            p.hset(key, 'host', node())
             # Set scheduler key to expire a few seconds after polling interval
             # This way, the key will automatically expire if scheduler
             # quits unexpectedly

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -17,6 +17,7 @@ from .utils import from_unix, to_unix
 
 logger = logging.getLogger(__name__)
 
+
 class Scheduler(object):
     scheduler_key = 'rq:scheduler'
     scheduled_jobs_key = 'rq:scheduler:scheduled_jobs'
@@ -279,8 +280,9 @@ class Scheduler(object):
 
         if interval:
             # If this is a repeat job and counter has reached 0, don't repeat
-            if repeat is not None and job.meta.get('repeat', 0) == 0:
-                return
+            if repeat is not None:
+                if job.meta['repeat'] == 0:
+                    return
             self.connection._zadd(self.scheduled_jobs_key,
                                   to_unix(datetime.utcnow()) + int(interval),
                                   job.id)
@@ -294,8 +296,6 @@ class Scheduler(object):
         jobs = self.get_jobs_to_queue()
         for job in jobs:
             self.enqueue_job(job)
-
-        self.log.info("Scheduled {0} jobs".format(jobs))
 
         # Refresh scheduler key's expiry
         self.connection.expire(self.scheduler_key, int(self._interval) + 10)
@@ -311,7 +311,7 @@ class Scheduler(object):
         self._install_signal_handlers()
         try:
             while True:
-                _ = self.enqueue_jobs()
+                self.enqueue_jobs()
                 time.sleep(self._interval)
         finally:
             self.register_death()


### PR DESCRIPTION
This way we can see *what* host is currently running the scheduler (or did in the past).