### PR TITLE
Allow multiple schedulers to run

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -27,28 +27,27 @@ class Scheduler(object):
         self.queue_name = queue_name
         self._interval = interval
         self.log = logger
+        self._lock_acquired = False
 
-    def register_birth(self):
-        if self.connection.exists(self.scheduler_key) and \
-                not self.connection.hexists(self.scheduler_key, 'death'):
-            raise ValueError("There's already an active RQ scheduler")
+    def acquire_lock(self):
+        """
+        Acquire lock before scheduling jobs to prevent another scheduler
+        from scheduling jobs at the same time.
+
+        This function returns True if a lock is acquired. False otherwise.
+        """
         key = self.scheduler_key
         now = time.time()
-        with self.connection._pipeline() as p:
-            p.delete(key)
-            p.hset(key, 'birth', now)
-            # Set scheduler key to expire a few seconds after polling interval
-            # This way, the key will automatically expire if scheduler
-            # quits unexpectedly
-            p.expire(key, int(self._interval) + 10)
-            p.execute()
+        expires = int(self._interval) + 10
+        self._lock_acquired = self.connection.set(key, now, ex=expires, nx=True)
+        return self._lock_acquired
 
-    def register_death(self):
-        """Registers its own death."""
-        with self.connection._pipeline() as p:
-            p.hset(self.scheduler_key, 'death', time.time())
-            p.expire(self.scheduler_key, 60)
-            p.execute()
+    def remove_lock(self):
+        """
+        Remove acquired lock.
+        """
+        if self._lock_acquired:
+            self.connection.delete(self.scheduler_key)
 
     def _install_signal_handlers(self):
         """
@@ -58,10 +57,10 @@ class Scheduler(object):
 
         def stop(signum, frame):
             """
-            Register scheduler's death and exit.
+            Remove previously acquired lock and exit.
             """
             self.log.info('Shutting down RQ scheduler...')
-            self.register_death()
+            self.remove_lock()
             raise SystemExit()
 
         signal.signal(signal.SIGINT, stop)
@@ -302,11 +301,11 @@ class Scheduler(object):
         lower than current time).
         """
         self.log.info('Running RQ scheduler...')
-        self.register_birth()
         self._install_signal_handlers()
         try:
             while True:
-                self.enqueue_jobs()
+                if self.acquire_lock():
+                    self.enqueue_jobs()
                 time.sleep(self._interval)
         finally:
-            self.register_death()
+            self.remove_lock()


### PR DESCRIPTION
Schedulers have to acquire a lock before one can schedule jobs. The
lock automatically expires in case a scheduler is terminated unexpectedly.
Schedulers that cannot acquire a lock will sleep for the duration of
polling interval before retrying.

refs #70
