### PR TITLE
Added support for setting the job timeout when scheduling jobs via cron.

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -154,7 +154,8 @@ class Scheduler(object):
         return job
 
 
-    def cron(self, cron_string, func, args=None, kwargs=None, repeat=None, queue_name=None):
+    def cron(self, cron_string, func, args=None, kwargs=None, repeat=None, queue_name=None,
+             timeout=None):
         """
         Schedule a cronjob
         """
@@ -167,6 +168,8 @@ class Scheduler(object):
 
         if repeat is not None:
             job.meta['repeat'] = int(repeat)
+        if timeout is not None:
+            job.timeout = timeout
 
         job.save()
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -270,6 +270,16 @@ class TestScheduler(RQTestCase):
         assert datetime_time.second == 0
         assert datetime_time - datetime.utcnow() < timedelta(hours=1)
 
+    def test_crontab_sets_id(self):
+        """
+        Ensure that a job scheduled via crontab can be created with
+        a custom timeout.
+        """
+        timeout = 13
+        job = self.scheduler.cron("1 * * * *", say_hello, timeout=timeout)
+        job_from_queue = Job.fetch(job.id, connection=self.testconn)
+        self.assertEqual(job_from_queue.timeout, timeout)
+
     def test_repeat_without_interval_raises_error(self):
         # Ensure that an error is raised if repeat is specified without interval
         def create_job():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -270,7 +270,7 @@ class TestScheduler(RQTestCase):
         assert datetime_time.second == 0
         assert datetime_time - datetime.utcnow() < timedelta(hours=1)
 
-    def test_crontab_sets_id(self):
+    def test_crontab_sets_timeout(self):
         """
         Ensure that a job scheduled via crontab can be created with
         a custom timeout.


### PR DESCRIPTION
While this adds support for `timeout` only, why is `cron` missing the other relevant parameters (`ttl`, `id` and `description`)?