### PR TITLE
Jobs scheduled via cron no longer expire automatically after 500 sec.

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -153,15 +153,16 @@ class Scheduler(object):
                               job.id)
         return job
 
-
     def cron(self, cron_string, func, args=None, kwargs=None, repeat=None, queue_name=None):
         """
         Schedule a cronjob
         """
         scheduled_time = get_next_scheduled_time(cron_string)
 
+        # Set result_ttl to -1, as jobs scheduled via cron are periodic ones.
+        # Otherwise the job would expire after 500 sec.
         job = self._create_job(func, args=args, kwargs=kwargs, commit=False,
-                               result_ttl=None, queue_name=queue_name)
+                               result_ttl=-1, queue_name=queue_name)
 
         job.meta['cron_string'] = cron_string
 
@@ -174,7 +175,6 @@ class Scheduler(object):
                               to_unix(scheduled_time),
                               job.id)
         return job
-
 
     def enqueue(self, scheduled_time, func, args=None, kwargs=None,
                 interval=None, repeat=None, result_ttl=None, queue_name=None):


### PR DESCRIPTION
Jobs scheduled via `Scheduler.cron` expire automatically after 500 sec if the time between two job executions exceeds 500 sec.