### PR TITLE
Implement count() methods

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -3,6 +3,7 @@ import signal
 import time
 import warnings
 
+from collections import defaultdict
 from datetime import datetime, timedelta
 from itertools import repeat
 
@@ -226,6 +227,54 @@ class Scheduler(object):
                         raise ValueError('Job not in scheduled jobs queue')
                     continue
 
+    def _rationalize_until(self, until=None):
+        """
+        Rationalizes the `until` argument used by other functions. This function
+        accepts datetime and timedelta instances as well as integers representing
+        epoch values.
+        """
+        if until is None:
+            until = "+inf"
+        elif isinstance(until, datetime):
+            until = to_unix(until)
+        elif isinstance(until, timedelta):
+            until = to_unix((datetime.utcnow() + until))
+        return until
+
+    def get_job_count(self, until=None):
+        """
+        Returns the total number of jobs that are scheduled for all queues. This function
+        accepts datetime and timedelta instances as well as integers representing epoch
+        values.
+        """
+
+        until = self._rationalize_until(until)
+        return self.connection.zcount(self.scheduled_jobs_key, 0, until)
+
+    def get_job_count_by_queue(self, until=None):
+        """
+        Returns a dictionary keyed by queue name with the values being the number
+        of jobs scheduled for each queue. This function accepts datetime and timedelta
+        instances as well as integers representing epoch values.
+
+        NOTE: Use carefully - this implementation retrieves all scheduled job IDs from
+        Redis and then retrieves the `origin` value from the hash for each job. This can get
+        quite slow when there is a large number of jobs - think on the order of several
+        seconds when there are 100,000 jobs scheduled.
+        """
+
+        until = self._rationalize_until(until)
+        job_ids = self.connection.zrangebyscore(self.scheduled_jobs_key, 0, until)
+        counts = defaultdict(int)
+        pipeline = self.connection.pipeline()
+        for job_id in job_ids:
+            r = pipeline.hget(Job.key_for(job_id), 'origin')
+
+        res = pipeline.execute()
+        for r in res:
+            counts[r] += 1
+        return counts
+
     def get_jobs(self, until=None, with_times=False):
         """
         Returns a list of job instances that will be queued until the given time.
@@ -238,12 +287,7 @@ class Scheduler(object):
         def epoch_to_datetime(epoch):
             return from_unix(float(epoch))
 
-        if until is None:
-            until = "+inf"
-        elif isinstance(until, datetime):
-            until = to_unix(until)
-        elif isinstance(until, timedelta):
-            until = to_unix((datetime.utcnow() + until))
+        until = self._rationalize_until(until)
         job_ids = self.connection.zrangebyscore(self.scheduled_jobs_key, 0,
                                                 until, withscores=with_times,
                                                 score_cast_func=epoch_to_datetime)

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -273,7 +273,7 @@ class Scheduler(object):
 
         res = pipeline.execute()
         for r in res:
-            counts[r] += 1
+            counts[r.decode('utf-8')] += 1
         return counts
 
     def get_jobs(self, until=None, with_times=False):

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -268,6 +268,7 @@ class Scheduler(object):
         counts = defaultdict(int)
         pipeline = self.connection.pipeline()
         for job_id in job_ids:
+            job_id = job_id.decode('utf-8')
             r = pipeline.hget(Job.key_for(job_id), 'origin')
 
         res = pipeline.execute()

--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -37,7 +37,7 @@ def setup_loghandlers(level='INFO'):
         logger.addHandler(handler)
 
 
-def rationalize_until(self, until=None):
+def rationalize_until(until=None):
     """
     Rationalizes the `until` argument used by other functions. This function
     accepts datetime and timedelta instances as well as integers representing

--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -1,7 +1,7 @@
 import calendar
 import croniter
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 
 from rq.utils import ColorizingStreamHandler
@@ -35,3 +35,18 @@ def setup_loghandlers(level='INFO'):
         handler = ColorizingStreamHandler()
         handler.setFormatter(formatter)
         logger.addHandler(handler)
+
+
+def rationalize_until(self, until=None):
+    """
+    Rationalizes the `until` argument used by other functions. This function
+    accepts datetime and timedelta instances as well as integers representing
+    epoch values.
+    """
+    if until is None:
+        until = "+inf"
+    elif isinstance(until, datetime):
+        until = to_unix(until)
+    elif isinstance(until, timedelta):
+        until = to_unix((datetime.utcnow() + until))
+    return until

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -131,7 +131,7 @@ class TestScheduler(RQTestCase):
     def test_get_job_count_by_queue(self):
         now = datetime.utcnow()
         queues = ['fee', 'fi', 'fo', 'fum']
-        counts = {queue: random.randint(10, 20) for queue in queues}
+        counts = dict((queue, random.randint(10, 20)) for queue in queues)
         for queue in queues:
             scheduler = Scheduler(connection=self.testconn, queue_name=queue)
             for x in range(counts[queue]):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -128,18 +128,6 @@ class TestScheduler(RQTestCase):
             self.scheduler.enqueue_at(now, say_hello)
         self.assertEqual(count, self.scheduler.get_job_count())
 
-    def test_get_job_count_by_queue(self):
-        now = datetime.utcnow()
-        queues = ['fee', 'fi', 'fo', 'fum']
-        counts = dict((queue, random.randint(10, 20)) for queue in queues)
-        for queue in queues:
-            scheduler = Scheduler(connection=self.testconn, queue_name=queue)
-            for x in range(counts[queue]):
-                scheduler.enqueue_at(now, say_hello)
-        job_counts = self.scheduler.get_job_count_by_queue()
-        for queue in queues:
-            self.assertEqual(counts[queue], job_counts[queue])
-
     def test_get_jobs(self):
         """
         Ensure get_jobs() returns all jobs until the specified time.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -136,7 +136,9 @@ class TestScheduler(RQTestCase):
             scheduler = Scheduler(connection=self.testconn, queue_name=queue)
             for x in range(counts[queue]):
                 scheduler.enqueue_at(now, say_hello)
-        self.assertEqual(counts, self.scheduler.get_job_count_by_queue())
+        job_counts = self.scheduler.get_job_count_by_queue()
+        for queue in queues:
+            self.assertEqual(counts[queue], job_counts[queue])
 
     def test_get_jobs(self):
         """

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -127,7 +127,7 @@ class TestScheduler(RQTestCase):
         count = random.randint(10, 20)
         for x in range(count):
             self.scheduler.enqueue_at(now, say_hello)
-        self.assertEqual(count, self.scheduler.get_job_count())
+        self.assertEqual(count, self.scheduler.count())
 
     def test_get_jobs(self):
         """

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -122,12 +122,22 @@ class TestScheduler(RQTestCase):
         self.assertEqual(self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id),
                          to_unix(right_now + time_delta))
 
-    def test_get_job_count(self):
+    def test_count(self):
         now = datetime.utcnow()
-        count = random.randint(10, 20)
-        for x in range(count):
+        count1 = random.randint(10, 20)
+        for x in range(count1):
             self.scheduler.enqueue_at(now, say_hello)
-        self.assertEqual(count, self.scheduler.count())
+        self.assertEqual(count1, self.scheduler.count())
+
+        future_time = now + timedelta(hours=1)
+        future_test_time = now + timedelta(minutes=59, seconds=59)
+        count2 = random.randint(10, 20)
+        for x in range(count2):
+            self.scheduler.enqueue_at(future_time, say_hello)
+
+        self.assertEqual(count1, self.scheduler.count(timedelta(minutes=59, seconds=59)))
+        self.assertEqual(count1, self.scheduler.count(future_test_time))
+        self.assertEqual(count1+count2, self.scheduler.count())
 
     def test_get_jobs(self):
         """


### PR DESCRIPTION
Added `get_job_count()` and `get_job_count_by_queue()` to `Scheduler` and associated tests.

Closes #118. Probably required for
https://github.com/ui/django-rq/pull/121.