### PR TITLE
Timeout argument for ._create_job(), .enqueue_at(), enqueue_in()

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -67,7 +67,8 @@ class Scheduler(object):
         signal.signal(signal.SIGTERM, stop)
 
     def _create_job(self, func, args=None, kwargs=None, commit=True,
-                    result_ttl=None, ttl=None, id=None, description=None, queue_name=None):
+                    result_ttl=None, ttl=None, id=None, description=None,
+                    queue_name=None, timeout=None):
         """
         Creates an RQ job and saves it to Redis.
         """
@@ -76,7 +77,8 @@ class Scheduler(object):
         if kwargs is None:
             kwargs = {}
         job = Job.create(func, args=args, connection=self.connection,
-                         kwargs=kwargs, result_ttl=result_ttl, ttl=ttl, id=id, description=description)
+                         kwargs=kwargs, result_ttl=result_ttl, ttl=ttl, id=id,
+                         description=description, timeout=timeout)
         job.origin = queue_name or self.queue_name
         if commit:
             job.save()
@@ -128,7 +130,8 @@ class Scheduler(object):
             result_ttl = -1
         job = self._create_job(func, args=args, kwargs=kwargs, commit=False,
                                result_ttl=result_ttl, ttl=ttl, id=id,
-                               description=description, queue_name=queue_name)
+                               description=description, queue_name=queue_name,
+                               timeout=timeout)
 
         if interval is not None:
             job.meta['interval'] = int(interval)
@@ -136,8 +139,6 @@ class Scheduler(object):
             job.meta['repeat'] = int(repeat)
         if repeat and interval is None:
             raise ValueError("Can't repeat a job without interval argument")
-        if timeout is not None:
-            job.timeout = timeout
         job.save()
         self.connection._zadd(self.scheduled_jobs_key,
                               to_unix(scheduled_time),
@@ -154,14 +155,13 @@ class Scheduler(object):
         # Set result_ttl to -1, as jobs scheduled via cron are periodic ones.
         # Otherwise the job would expire after 500 sec.
         job = self._create_job(func, args=args, kwargs=kwargs, commit=False,
-                               result_ttl=-1, id=id, queue_name=queue_name, description=description)
+                               result_ttl=-1, id=id, queue_name=queue_name,
+                               description=description, timeout=timeout)
 
         job.meta['cron_string'] = cron_string
 
         if repeat is not None:
             job.meta['repeat'] = int(repeat)
-        if timeout is not None:
-            job.timeout = timeout
 
         job.save()
 

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -101,7 +101,9 @@ class Scheduler(object):
         scheduler = Scheduler(queue_name='default', connection=redis)
         scheduler.enqueue_at(datetime(2020, 1, 1), func, 'argument', keyword='argument')
         """
-        job = self._create_job(func, args=args, kwargs=kwargs)
+        timeout = kwargs.pop('timeout', None)
+
+        job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout)
         self.connection._zadd(self.scheduled_jobs_key,
                               to_unix(scheduled_time),
                               job.id)
@@ -113,7 +115,9 @@ class Scheduler(object):
         The job's scheduled execution time will be calculated by adding the timedelta
         to datetime.utcnow().
         """
-        job = self._create_job(func, args=args, kwargs=kwargs)
+        timeout = kwargs.pop('timeout', None)
+
+        job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout)
         self.connection._zadd(self.scheduled_jobs_key,
                               to_unix(datetime.utcnow() + time_delta),
                               job.id)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -85,6 +85,15 @@ class TestScheduler(RQTestCase):
         job_from_queue = Job.fetch(job.id, connection=self.testconn)
         self.assertEqual('description', job_from_queue.description)
 
+    def test_create_job_with_timeout(self):
+        """
+        Ensure that timeout is passed to RQ.
+        """
+        timeout = 13
+        job = self.scheduler._create_job(say_hello, timeout=13, args=(), kwargs={})
+        job_from_queue = Job.fetch(job.id, connection=self.testconn)
+        self.assertEqual(timeout, job_from_queue.timeout)
+
     def test_job_not_persisted_if_commit_false(self):
         """
         Ensure jobs are only saved to Redis if commit=True.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -113,6 +113,16 @@ class TestScheduler(RQTestCase):
         self.assertEqual(self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id),
                          to_unix(scheduled_time))
 
+    def test_enqueue_at_sets_timeout(self):
+        """
+        Ensure that a job scheduled via enqueue_at can be created with
+        a custom timeout.
+        """
+        timeout = 13
+        job = self.scheduler.enqueue_at(datetime.utcnow(), say_hello, timeout=timeout)
+        job_from_queue = Job.fetch(job.id, connection=self.testconn)
+        self.assertEqual(job_from_queue.timeout, timeout)
+
     def test_enqueue_in(self):
         """
         Ensure that jobs have the right scheduled time.
@@ -128,6 +138,16 @@ class TestScheduler(RQTestCase):
         job = self.scheduler.enqueue_in(time_delta, say_hello)
         self.assertEqual(self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id),
                          to_unix(right_now + time_delta))
+
+    def test_enqueue_in_sets_timeout(self):
+        """
+        Ensure that a job scheduled via enqueue_in can be created with
+        a custom timeout.
+        """
+        timeout = 13
+        job = self.scheduler.enqueue_in(timedelta(minutes=1), say_hello, timeout=timeout)
+        job_from_queue = Job.fetch(job.id, connection=self.testconn)
+        self.assertEqual(job_from_queue.timeout, timeout)
 
     def test_count(self):
         now = datetime.utcnow()


### PR DESCRIPTION
Scheduler._create_job()
*  now accepts also timeout argument
* added test for above
* cleanup of scheduler methods that were setting timeout not by `_create_job`

Scheduler.enqueue_at() + Scheduler.enqueue_in():
* added timeout argument that is popped from kwargs