### PR TITLE
Update scheduler.enqueue_at/in to accept job_id argument

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -102,8 +102,9 @@ class Scheduler(object):
         scheduler.enqueue_at(datetime(2020, 1, 1), func, 'argument', keyword='argument')
         """
         timeout = kwargs.pop('timeout', None)
+        job_id = kwargs.pop('job_id', None)
 
-        job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout)
+        job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout, id=job_id)
         self.connection._zadd(self.scheduled_jobs_key,
                               to_unix(scheduled_time),
                               job.id)
@@ -116,8 +117,9 @@ class Scheduler(object):
         to datetime.utcnow().
         """
         timeout = kwargs.pop('timeout', None)
+        job_id = kwargs.pop('job_id', None)
 
-        job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout)
+        job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout, id=job_id)
         self.connection._zadd(self.scheduled_jobs_key,
                               to_unix(datetime.utcnow() + time_delta),
                               job.id)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -123,6 +123,15 @@ class TestScheduler(RQTestCase):
         job_from_queue = Job.fetch(job.id, connection=self.testconn)
         self.assertEqual(job_from_queue.timeout, timeout)
 
+    def test_enqueue_at_sets_job_id(self):
+        """
+        Ensure that a job scheduled via enqueue_at can be created with
+        a custom job id.
+        """
+        job_id = 'test_id'
+        job = self.scheduler.enqueue_at(datetime.utcnow(), say_hello, job_id=job_id)
+        self.assertEqual(job.id, job_id)
+
     def test_enqueue_in(self):
         """
         Ensure that jobs have the right scheduled time.
@@ -148,6 +157,15 @@ class TestScheduler(RQTestCase):
         job = self.scheduler.enqueue_in(timedelta(minutes=1), say_hello, timeout=timeout)
         job_from_queue = Job.fetch(job.id, connection=self.testconn)
         self.assertEqual(job_from_queue.timeout, timeout)
+
+    def test_enqueue_in_sets_job_id(self):
+        """
+        Ensure that a job scheduled via enqueue_in can be created with
+        a custom job id.
+        """
+        job_id = 'test_id'
+        job = self.scheduler.enqueue_in(timedelta(minutes=1), say_hello, job_id=job_id)
+        self.assertEqual(job.id, job_id)
 
     def test_count(self):
         now = datetime.utcnow()


### PR DESCRIPTION
I had a need to specify a job id when scheduling a job, so I made the trivial modification to the enqueue_in and enqueue_at methods. Since RQ.Queue.enqueue supports the job_id parameter, it seems like a reasonable name to use for the public Scheduler methods.
