### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,6 +195,10 @@ same names but with a prefix of ``RQ_REDIS_``.
 Changelog
 =========
 
+Version 0.7.0
+
+* Added `timeout` kwarg to `scheduler.enqueue_in` and `scheduler.enqueue_at`. Thanks @lechup!
+
 Version 0.6.1
 -------------
 * Added `scheduler.count()`. Thanks @smaccona!

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if platform.python_version() < '2.7':
 
 setup(
     name='rq-scheduler',
-    version='0.6.1',
+    version='0.7.0',
     author='Selwin Ong',
     author_email='selwin.ong@gmail.com',
     packages=['rq_scheduler'],


### PR DESCRIPTION
My organization is using rq-scheduler and really needs that `timeout` argument in `enqueue_in` and `enqueue_at`. This commit simply bumps the version number so that we could upload the forked version to our internal PyPi. If you guys could please release some version that supports that keyword argument, we can just switch to that. This PR does not add any new functionality but rather is a request to release this new feature. At your earliest convenience, please. Thanks!