### PR TITLE
Updated enqueue_in/at to accept job_ttl and job_result_ttl arguments

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -131,8 +131,11 @@ class Scheduler(object):
         """
         timeout = kwargs.pop('timeout', None)
         job_id = kwargs.pop('job_id', None)
+        job_ttl = kwargs.pop('job_ttl', None)
+        job_result_ttl = kwargs.pop('job_result_ttl', None)
 
-        job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout, id=job_id)
+        job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout,
+                               id=job_id, result_ttl=job_result_ttl, ttl=job_ttl)
         self.connection._zadd(self.scheduled_jobs_key,
                               to_unix(scheduled_time),
                               job.id)
@@ -146,8 +149,11 @@ class Scheduler(object):
         """
         timeout = kwargs.pop('timeout', None)
         job_id = kwargs.pop('job_id', None)
+        job_ttl = kwargs.pop('job_ttl', None)
+        job_result_ttl = kwargs.pop('job_result_ttl', None)
 
-        job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout, id=job_id)
+        job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout,
+                               id=job_id, result_ttl=job_result_ttl, ttl=job_ttl)
         self.connection._zadd(self.scheduled_jobs_key,
                               to_unix(datetime.utcnow() + time_delta),
                               job.id)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -148,6 +148,22 @@ class TestScheduler(RQTestCase):
         job = self.scheduler.enqueue_at(datetime.utcnow(), say_hello, job_id=job_id)
         self.assertEqual(job.id, job_id)
 
+    def test_enqueue_at_sets_job_ttl(self):
+        """
+        Ensure that a job scheduled via enqueue_at can be created with a custom job ttl.
+        """
+        job_ttl = 123456789
+        job = self.scheduler.enqueue_at(datetime.utcnow(), say_hello, job_ttl=job_ttl)
+        self.assertEqual(job.ttl, job_ttl)
+
+    def test_enqueue_at_sets_job_result_ttl(self):
+        """
+        Ensure that a job scheduled via enqueue_at can be created with a custom result ttl.
+        """
+        job_result_ttl = 1234567890
+        job = self.scheduler.enqueue_at(datetime.utcnow(), say_hello, job_result_ttl=job_result_ttl)
+        self.assertEqual(job.result_ttl, job_result_ttl)
+
     def test_enqueue_in(self):
         """
         Ensure that jobs have the right scheduled time.
@@ -182,6 +198,22 @@ class TestScheduler(RQTestCase):
         job_id = 'test_id'
         job = self.scheduler.enqueue_in(timedelta(minutes=1), say_hello, job_id=job_id)
         self.assertEqual(job.id, job_id)
+
+    def test_enqueue_in_sets_job_ttl(self):
+        """
+        Ensure that a job scheduled via enqueue_in can be created with a custom job ttl.
+        """
+        job_ttl = 123456789
+        job = self.scheduler.enqueue_in(timedelta(minutes=1), say_hello, job_ttl=job_ttl)
+        self.assertEqual(job.ttl, job_ttl)
+
+    def test_enqueue_in_sets_job_result_ttl(self):
+        """
+        Ensure that a job scheduled via enqueue_in can be created with a custom result ttl.
+        """
+        job_result_ttl = 1234567890
+        job = self.scheduler.enqueue_in(timedelta(minutes=1), say_hello, job_result_ttl=job_result_ttl)
+        self.assertEqual(job.result_ttl, job_result_ttl)
 
     def test_count(self):
         now = datetime.utcnow()


### PR DESCRIPTION
In some cases, I had to specify job ttl and result ttl when scheduling a job, so I made the minor patch to the enqueue_in and enqueue_at methods similar to a job_id argument.