### PR TITLE
cron only once if all configuration is identical

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,8 @@ This is how you do it
         queue_name=queue_name       # In which queue the job should be put in
     )
 
+    scheduler.cron_once  # cron only once if all configuration is identical, return False if alreay cron
+
 -------------------------
 Retrieving scheduled jobs
 -------------------------


### PR DESCRIPTION
- use zrangebyscore and next scheduled time to get posssible related job ids
- if has identical job configuration, return false 