### PR TITLE
Add "-q" flag that will silence INFO messages

### DIFF
--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -18,6 +18,7 @@ def main():
     parser.add_argument('-d', '--db', default=int(os.environ.get('RQ_REDIS_DB', 0)), type=int, help="Redis database")
     parser.add_argument('-P', '--password', default=os.environ.get('RQ_REDIS_PASSWORD'), help="Redis password")
     parser.add_argument('--verbose', '-v', action='store_true', default=False, help='Show more output')
+    parser.add_argument('--quiet', '-q', action='store_true', default=False, help='Show less output')
     parser.add_argument('--url', '-u', default=os.environ.get('RQ_REDIS_URL')
         , help='URL describing Redis connection details. \
             Overrides other connection arguments if supplied.')
@@ -45,6 +46,8 @@ def main():
 
     if args.verbose:
         level = 'DEBUG'
+    elif args.quiet:
+        level = 'WARNING'
     else:
         level = 'INFO'
     setup_loghandlers(level)


### PR DESCRIPTION
RQScheduler will consistently pour "Checking for scheduled jobs..." into the console at a very fast clip, depending on the interval. In this PR, I add a `-q` or `--quiet` that does the opposite of `--verbose` and tones down logging to WARNING or above.